### PR TITLE
Let plugins alter snippets list using add_filter

### DIFF
--- a/lib/PostSnippets/WPEditor.php
+++ b/lib/PostSnippets/WPEditor.php
@@ -166,6 +166,10 @@ class PostSnippets_WPEditor
         # so they can be inserted into the editor, and get the variables replaced
         # with user defined strings.
         $snippets = get_option(PostSnippets::OPTION_KEY, array());
+
+        //Let other plugins change the shortcodes list
+        $snippets = apply_filters('post_snippets_snippets_list', $snippets);
+
         foreach ($snippets as $key => $snippet) {
             if ($snippet['shortcode']) {
                 # Build a long string of the variables, ie: varname1={varname1} varname2={varname2}
@@ -298,7 +302,13 @@ class PostSnippets_WPEditor
      */
     public function addJqueryUiDialog()
     {
-        $data = array('snippets' => get_option(PostSnippets::OPTION_KEY, array()));
+        $snippets = get_option(PostSnippets::OPTION_KEY, array());
+
+        //Let other plugins change the shortcodes list
+        $snippets = apply_filters('post_snippets_snippets_list', $snippets);
+
+        $data = array('snippets' => $snippets);
+
         echo PostSnippets_View::render('jquery-ui-dialog', $data);
     }
 


### PR DESCRIPTION
Added a filter so that external plugins can modify the post snippets list.

The reason for this is that I am maintaining a plugin that creates a shortcode, and wanted an easy way for users to add it into the TinyMCE editor, while not causing extra bloat to my plugin.

You can try out the development build of my plugin (Email Obfuscate Shortcode), using the Post Snippets integration here:
https://github.com/khromov/wp-email-obfuscate-shortcode/tree/devel

Here's what it looks like. The email-obfuscate shortcode is inserted by the plugin.
![Screenshot](https://dl.dropboxusercontent.com/u/2758854/email-obfuscate-filter.png)