### PR TITLE
Only initiate tabs if there's tabs to initiate (prevent plugin conflict)

### DIFF
--- a/src/PostSnippets/WPEditor.php
+++ b/src/PostSnippets/WPEditor.php
@@ -232,76 +232,78 @@ class PostSnippets_WPEditor
         }
         ?>
 
-            var tabs = $("#post-snippets-tabs").tabs();
-
-            $(function() {
-                $( "#post-snippets-dialog" ).dialog({
-                    autoOpen: false,
-                    modal: true,
-                    dialogClass: 'wp-dialog',
-                    buttons: {
-                        Cancel: function() {
-                            $( this ).dialog( "close" );
-                        },
-                        "Insert": function() {
-                            $(this).dialog("close");
-                        <?php
-                        global $wp_version;
-        if (version_compare($wp_version, '3.5', '<')) {
-            ?>
-                            var selected = tabs.tabs('option', 'selected');
-                        <?php
-
-        } else {
-            ?>
-                            var selected = tabs.tabs('option', 'active');
-                        <?php
-
-        }
-        ?>
-                        <?php
-        foreach ($snippets as $key => $snippet) {
-            ?>
-                                if (selected == <?php echo $key;
-            ?>) {
-                                    insert_snippet = postsnippet_<?php echo $key;
-            ?>;
-                                    <?php
-                                    $var_arr = explode(",", $snippet['vars']);
-            if (!empty($var_arr[0])) {
-                foreach ($var_arr as $key_2 => $var) {
-                    $varname = "var_" . $key . "_" . $key_2;
-                    ?>
-                                            insert_snippet = insert_snippet.replace(/\{<?php
-                                            echo $this->stripDefaultVal($var);
-                    ?>\}/g, <?php echo $varname;
-                    ?>.val());
-            <?php
-                    echo "\n";
-                }
+			if($("#post-snippets-tabs").length>0){ // Only initiate if there's tabs
+	            var tabs = $("#post-snippets-tabs").tabs();
+	
+	            $(function() {
+	                $( "#post-snippets-dialog" ).dialog({
+	                    autoOpen: false,
+	                    modal: true,
+	                    dialogClass: 'wp-dialog',
+	                    buttons: {
+	                        Cancel: function() {
+	                            $( this ).dialog( "close" );
+	                        },
+	                        "Insert": function() {
+	                            $(this).dialog("close");
+	                        <?php
+	                        global $wp_version;
+	        if (version_compare($wp_version, '3.5', '<')) {
+	            ?>
+	                            var selected = tabs.tabs('option', 'selected');
+	                        <?php
+	
+	        } else {
+	            ?>
+	                            var selected = tabs.tabs('option', 'active');
+	                        <?php
+	
+	        }
+	        ?>
+	                        <?php
+	        foreach ($snippets as $key => $snippet) {
+	            ?>
+	                                if (selected == <?php echo $key;
+	            ?>) {
+	                                    insert_snippet = postsnippet_<?php echo $key;
+	            ?>;
+	                                    <?php
+	                                    $var_arr = explode(",", $snippet['vars']);
+	            if (!empty($var_arr[0])) {
+	                foreach ($var_arr as $key_2 => $var) {
+	                    $varname = "var_" . $key . "_" . $key_2;
+	                    ?>
+	                                            insert_snippet = insert_snippet.replace(/\{<?php
+	                                            echo $this->stripDefaultVal($var);
+	                    ?>\}/g, <?php echo $varname;
+	                    ?>.val());
+	            <?php
+	                    echo "\n";
+	                }
+	            }
+	            ?>
+	                                }
+	        <?php
+	
+	        }
+	        ?>
+	
+	                            // Decide what method to use to insert the snippet depending
+	                            // from what editor the window was opened from
+	                            if (post_snippets_caller == 'html') {
+	                                // HTML editor in WordPress 3.3 and greater
+	                                QTags.insertContent(insert_snippet);
+	                            } else {
+	                                // Visual Editor
+	                                post_snippets_canvas.execCommand('mceInsertContent', false, insert_snippet);
+	                            }
+	
+	                        }
+	                    },
+	                    width: 500,
+	                });
+	            });
             }
-            ?>
-                                }
-        <?php
-
-        }
-        ?>
-
-                            // Decide what method to use to insert the snippet depending
-                            // from what editor the window was opened from
-                            if (post_snippets_caller == 'html') {
-                                // HTML editor in WordPress 3.3 and greater
-                                QTags.insertContent(insert_snippet);
-                            } else {
-                                // Visual Editor
-                                post_snippets_canvas.execCommand('mceInsertContent', false, insert_snippet);
-                            }
-
-                        }
-                    },
-                    width: 500,
-                });
-            });
         });
 
         // Global variables to keep track on the canvas instance and from what editor


### PR DESCRIPTION
I use Download Monitor (https://www.download-monitor.com) on my site, and the Insert Download popup was having a JavaScript error since this plugin was trying to initiate .tabs(); even though there weren't any tabs present (and jQuery UI hadn't been called).

This is quick fix that checks to make sure Post Snippet tabs are present before trying to initiate jQuery UI tabs. A more permanent fix might be to resolve why this plugin's script being executed when a different plugin is opening a popup in the editor, but I'm not familiar enough with this plugin's code to dive into that. This is just a quick & harmless fix (added if statement wrapping existing code so it only runs when there's tabs present).